### PR TITLE
fix: tests and docs regarding regex escaping

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ func myfunc(c config) {
 # Formatting notes
 
 - Boolean values are evaluated with [strconv.ParseBool](https://pkg.go.dev/strconv#ParseBool).
-- Regular expressions are evaluated with [regex.Compile](https://pkg.go.dev/regexp#Compile).
+- Regular expressions are evaluated with [regex.Compile](https://pkg.go.dev/regexp#Compile). Backslashes in a regular expressions should be escaped with another backslash, i.e. "\." -> "\\."
 - Ranges are expressed with single values (e.g. `1`, `11`, `1024`) and/or ranges (e.g. `10-20`) separated by commas. Example: `"80, 443, 1024-65535"`.
 - Whitespace is ignored in all values representing sets of values and ranges.
 

--- a/defcon_test.go
+++ b/defcon_test.go
@@ -1660,3 +1660,37 @@ func TestInvalidTypeSliceValidRange(t *testing.T) {
 		t.Errorf("Type float should not be used with valid range")
 	}
 }
+
+func TestMustMatchEmail(t *testing.T) {
+
+	type valid struct {
+		Email string `mustmatch:"^[a-z0-9._%+\\-]+@[a-z0-9.\\-]+\\.[a-z]{2,4}$"`
+	}
+
+	v := valid{
+		Email: "me@example.com",
+	}
+
+	err := CheckStruct(&v)
+	if err != nil {
+		t.Errorf("Email should be valid")
+	}
+
+}
+
+func TestMustMatchInvalidEmail(t *testing.T) {
+
+	type valid struct {
+		Email string `mustmatch:"^[a-z0-9._%+\\-]+@[a-z0-9.\\-]+\\.[a-z]{2,4}$"`
+	}
+
+	v := valid{
+		Email: "me@nope@example.com",
+	}
+
+	err := CheckStruct(&v)
+	if err == nil {
+		t.Errorf("Email should be invalid")
+	}
+
+}


### PR DESCRIPTION
Adds testing and documentation on how to escape backslashes in mustmatch and mustnotmatch regular expressions. Previous example did not pass build.